### PR TITLE
ICU-22007 remove outdated terms of use from Unicode conversion files

### DIFF
--- a/charset/data/ucm/iso-8859_1-1998.ucm
+++ b/charset/data/ucm/iso-8859_1-1998.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-1:1998 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,15 +16,16 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_1-1998"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_10-1998.ucm
+++ b/charset/data/ucm/iso-8859_10-1998.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-10:1998 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.1
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 October 11
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 October 11 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -31,14 +17,15 @@
 #
 #	Version history
 #	1.0 version new.
-#       1.1 corrected mistake in mapping of 0xA4
+#   1.1 corrected mistake in mapping of 0xA4
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_10-1998"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_11-2001.ucm
+++ b/charset/data/ucm/iso-8859_11-2001.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-11:2001 to Unicode
 #	Unicode version:  3.2
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             2002 October 7
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 2002 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             2002 October 7 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -34,13 +20,14 @@
 #
 #	Version history:
 #		2002 October 7  Created
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	For any comments or problems, please use the Unicode
-#	web contact form at:
-#		http://www.unicode.org/unicode/reporting.html
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_11-2001"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_13-1998.ucm
+++ b/charset/data/ucm/iso-8859_13-1998.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-13:1998  to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1998 - 1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -29,12 +15,16 @@
 #
 #	Format:  The ICU UCM format
 #
-#	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#	Version history
+#   1.0 version: created
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Updated versions of this file may be found in:
+#		http://www.unicode.org/Public/MAPPINGS/
+#
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_13-1998"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_14-1998.ucm
+++ b/charset/data/ucm/iso-8859_14-1998.ucm
@@ -1,27 +1,13 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-14:1998 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Markus Kuhn <mkuhn@acm.org>
-#			  Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1998 - 1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/>
+#			  Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,12 +16,16 @@
 #
 #	Format:  The ICU UCM format
 #
-#	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#	Version history
+#   1.0 version: created
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Updated versions of this file may be found in:
+#		http://www.unicode.org/Public/MAPPINGS/
+#
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_14-1998"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_15-1999.ucm
+++ b/charset/data/ucm/iso-8859_15-1999.ucm
@@ -1,27 +1,13 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-15:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Markus Kuhn <mkuhn@acm.org>
-#			  Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1998 - 1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/>
+#			  Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -31,13 +17,15 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
+#   1.0 version: created
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_15-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_16-2001.ucm
+++ b/charset/data/ucm/iso-8859_16-2001.ucm
@@ -1,26 +1,14 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-16:2001 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             2001 July 26
-#	Authors:          Markus Kuhn <mkuhn@acm.org>
+#	Date:             2001 July 26 (header updated: 2015 December 02)
+#	Authors:          Markus Kuhn <http://www.cl.cam.ac.uk/~mgk25/>
 #
 #	Copyright (c) 1999-2001 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
 #
 #	General notes:
 #
@@ -29,12 +17,16 @@
 #
 #	Format:  The ICU UCM format
 #
-#	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#	Version history
+#   1.0 version: created
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Updated versions of this file may be found in:
+#		http://www.unicode.org/Public/MAPPINGS/
+#
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_16-2001"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_2-1999.ucm
+++ b/charset/data/ucm/iso-8859_2-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO 8859-2:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,15 +16,16 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_2-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_3-1999.ucm
+++ b/charset/data/ucm/iso-8859_3-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-3:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,15 +16,16 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_3-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_4-1998.ucm
+++ b/charset/data/ucm/iso-8859_4-1998.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-4:1998 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,15 +16,16 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_4-1998"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_5-1999.ucm
+++ b/charset/data/ucm/iso-8859_5-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO 8859-5:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,15 +16,16 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_5-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_6-1999.ucm
+++ b/charset/data/ucm/iso-8859_6-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO 8859-6:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -30,17 +16,18 @@
 #	Format:  The ICU UCM format
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
-#	0x30..0x39 remapped to the ASCII digits (U+0030..U+0039) instead
-#	of the Arabic digits (U+0660..U+0669).
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#       0x30..0x39 remapped to the ASCII digits (U+0030..U+0039) instead
+#       of the Arabic digits (U+0660..U+0669).
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_6-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_7-2003.ucm
+++ b/charset/data/ucm/iso-8859_7-2003.ucm
@@ -1,52 +1,41 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
-#   Name:             ISO 8859-7:2003 to Unicode
-#   Unicode version:  4.0
-#   Table version:    2.0
-#   Table format:     Format A
-#   Date:             2003-Nov-12
-#   Authors:          Ken Whistler <kenw@sybase.com>
+#	Name:             ISO 8859-7:2003 to Unicode
+#	Unicode version:  4.0
+#	Table version:    3.0
+#	Table format:     Format A
+#	Date:             2003-Nov-12 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
-#   Copyright (c) 1991-2003 Unicode, Inc.  All Rights reserved.
+#	General notes:
 #
-#   This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#   No claims are made as to fitness for any particular purpose.  No
-#   warranties of any kind are expressed or implied.  The recipient
-#   agrees to determine applicability of information provided.  If this
-#   file has been provided on optical media by Unicode, Inc., the sole
-#   remedy for any claim will be exchange of defective media within 90
-#   days of receipt.
-#
-#   Unicode, Inc. hereby grants the right to freely use the information
-#   supplied in this file in the creation of products supporting the
-#   Unicode Standard, and to make copies of this file in any form for
-#   internal or external distribution as long as this notice remains
-#   attached.
-#
-#   General notes:
-#
-#   This table contains the data the Unicode Consortium has on how
+#	This table contains the data the Unicode Consortium has on how
 #       ISO 8859-7:2003 characters map into Unicode.
 #
-#   ISO 8859-7:1987 is equivalent to ISO-IR-126, ELOT 928,
-#   and ECMA 118. ISO 8859-7:2003 adds two currency signs 
-#   and one other character not in the earlier standard.
+#	ISO 8859-7:1987 is equivalent to ISO-IR-126, ELOT 928,
+#	and ECMA 118. ISO 8859-7:2003 adds two currency signs 
+#	and one other character not in the earlier standard.
 #
-#   Format:  The ICU UCM format
+#	Format:  The ICU UCM format
 #
-#   Version history
-#   1.0 version updates 0.1 version by adding mappings for all
-#   control characters.
-#   Remap 0xA1 to U+2018 (instead of 0x02BD) to match text of 8859-7
-#   Remap 0xA2 to U+2019 (instead of 0x02BC) to match text of 8859-7
+#	Version history
+#	1.0 version updates 0.1 version by adding mappings for all
+#	control characters.
+#	Remap 0xA1 to U+2018 (instead of 0x02BD) to match text of 8859-7
+#	Remap 0xA2 to U+2019 (instead of 0x02BC) to match text of 8859-7
 #
-#   2.0 version updates 1.0 version by adding mappings for the
-#   three newly added characters 0xA4, 0xA5, 0xAA.
+#	2.0 version updates 1.0 version by adding mappings for the
+#	three newly added characters 0xA4, 0xA5, 0xAA.
 #
-#   Updated versions of this file may be found in:
-#       <http://www.unicode.org/Public/MAPPINGS/>
+#   3.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
-#   Any comments or problems, contact the Unicode Consortium at:
-#       <http://www.unicode.org/reporting.html>
+#	Updated versions of this file may be found in:
+#		http://www.unicode.org/Public/MAPPINGS/
+#
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_7-2003"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_8-1999.ucm
+++ b/charset/data/ucm/iso-8859_8-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-8:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.1
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             2000-Jan-03
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on optical media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             2000-Jan-03 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -32,15 +18,16 @@
 #	Version history
 #	1.0 version updates 0.1 version by adding mappings for all
 #	control characters.
-#       1.1 version updates to the published 8859-8:1999, correcting
+#   1.1 version updates to the published 8859-8:1999, correcting
 #          the mapping of 0xAF and adding mappings for LRM and RLM.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_8-1999"
 <mb_cur_max>                  1

--- a/charset/data/ucm/iso-8859_9-1999.ucm
+++ b/charset/data/ucm/iso-8859_9-1999.ucm
@@ -1,26 +1,12 @@
+# Copyright (C) 2015 and later: Unicode, Inc. and others.
+# License & terms of use: http://www.unicode.org/copyright.html
 #
 #	Name:             ISO/IEC 8859-9:1999 to Unicode
 #	Unicode version:  3.0
-#	Table version:    1.0
+#	Table version:    2.0
 #	Table format:     Format A
-#	Date:             1999 July 27
-#	Authors:          Ken Whistler <kenw@sybase.com>
-#
-#	Copyright (c) 1991-1999 Unicode, Inc.  All Rights reserved.
-#
-#	This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-#	No claims are made as to fitness for any particular purpose.  No
-#	warranties of any kind are expressed or implied.  The recipient
-#	agrees to determine applicability of information provided.  If this
-#	file has been provided on magnetic media by Unicode, Inc., the sole
-#	remedy for any claim will be exchange of defective media within 90
-#	days of receipt.
-#
-#	Unicode, Inc. hereby grants the right to freely use the information
-#	supplied in this file in the creation of products supporting the
-#	Unicode Standard, and to make copies of this file in any form for
-#	internal or external distribution as long as this notice remains
-#	attached.
+#	Date:             1999 July 27 (header updated: 2015 December 02)
+#	Authors:          Ken Whistler <ken@unicode.org>
 #
 #	General notes:
 #
@@ -32,15 +18,16 @@
 #	ISO/IEC 8859-9 is also equivalent to ISO-IR-148.
 #
 #	Version history
-#	1.0 version updates 0.1 version by adding mappings for all
-#	control characters.
+#   1.0 version: updates 0.1 version by adding mappings for all
+#       control characters.
+#   2.0 version: updates to copyright notice and terms of use; no
+#       changes to character mappings
 #
 #	Updated versions of this file may be found in:
-#		<ftp://ftp.unicode.org/Public/MAPPINGS/>
+#		http://www.unicode.org/Public/MAPPINGS/
 #
-#	Any comments or problems, contact <errata@unicode.org>
-#	Please note that <errata@unicode.org> is an archival address;
-#	notices will be checked, but do not expect an immediate response.
+#	Any comments or problems, contact us at:
+#       http://www.unicode.org/reporting.html
 #
 <code_set_name>               "iso-8859_9-1999"
 <mb_cur_max>                  1


### PR DESCRIPTION
Déjà vu: Same types of changes as in https://github.com/unicode-org/icu/pull/2073 but these files are in the ICU charset repository (in the icu-data repo), not in ICU itself (icu repo). Also, there are more files here than built into ICU by default.

Merges the changes in the Unicode MAPPINGS file headers into the ICU file headers.
- https://www.unicode.org/Public/MAPPINGS/ISO8859/
- https://github.com/unicode-org/icu-data/tree/main/charset/data/ucm

Preserves differences due to different file formats.

Note: The XML versions of these files do not carry copies of these headers, so we need not update those as well.
https://github.com/unicode-org/icu-data/tree/main/charset/data/xml